### PR TITLE
capacity checker and job load balancer

### DIFF
--- a/projects/cc-ooc-handler/README.md
+++ b/projects/cc-ooc-handler/README.md
@@ -46,7 +46,7 @@ The plugin is automatically installed by CycleCloud cluster-init. Manual install
 
 ```bash
 sudo /opt/cycle/jetpack/system/embedded/bin/bash \
-    /opt/cycle/jetpack/specs/default/cluster-init/scripts/00_install.sh
+    /opt/cycle/jetpack/specs/default/cluster-init/scripts/00_install_job_plugin.sh
 ```
 
 ## Files Installed

--- a/projects/cc-ooc-handler/README.md
+++ b/projects/cc-ooc-handler/README.md
@@ -1,0 +1,77 @@
+# cc-ooc-handler
+
+CycleCloud project for handling Out-of-Capacity (OOC) scenarios in Slurm clusters using load-balanced partition assignment.
+
+## Overview
+
+This project installs and configures a Slurm `job_submit` Lua plugin that intercepts job submissions and implements load-balanced partition assignment. When a job is submitted to a partition with configured fallbacks, the plugin automatically routes the job to the least-loaded partition, helping distribute workload and handle capacity constraints.
+
+## Features
+
+- Load-balanced partition assignment based on node allocation
+- Partition mapping configuration for fallback routing
+- Integration with capacity state tracking
+- Automatic skipping of partitions marked as INACTIVE
+
+## How It Works
+
+1. Define partition mappings in `/etc/slurm/partition_config.conf`
+2. When a job targets a mapped partition, the plugin queries current load
+3. The job is assigned to the least-loaded fallback partition
+4. Partitions marked INACTIVE in the state file are skipped
+
+## Configuration
+
+### Partition Mappings
+
+Edit `/etc/slurm/partition_config.conf` to define partition mappings:
+
+```
+# Format: partition: fallback1,fallback2,fallback3
+hpc: hpc_eastus,hpc_westus,hpc_northeu
+gpu: gpu_eastus,gpu_westus
+```
+
+### Installation Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DEBUG_LOGGING` | `false` | Enable verbose installation logging |
+| `SLURM_CONFIG_DIR` | `/etc/slurm` | Slurm configuration directory |
+| `SLURM_STATE_DIR` | `/var/run/slurm` | Directory for capacity state file |
+
+## Installation
+
+The plugin is automatically installed by CycleCloud cluster-init. Manual installation:
+
+```bash
+sudo /opt/cycle/jetpack/system/embedded/bin/bash \
+    /opt/cycle/jetpack/specs/default/cluster-init/scripts/00_install.sh
+```
+
+## Files Installed
+
+- `/etc/slurm/job_submit.lua` - Main plugin script
+- `/etc/slurm/partition_config.conf` - Partition mapping configuration
+- `/var/run/slurm/` - State directory for capacity tracking
+
+## Post-Installation
+
+After installation, restart slurmctld to load the plugin:
+
+```bash
+systemctl restart slurmctld
+```
+
+Verify the plugin is loaded:
+
+```bash
+scontrol show config | grep JobSubmitPlugins
+```
+
+## Customization
+
+To customize the plugin behavior:
+
+1. Edit partition mappings in `/etc/slurm/partition_config.conf`
+2. Provide a custom `partition_config.conf` in `specs/default/cluster-init/files/`

--- a/projects/cc-ooc-handler/project.ini
+++ b/projects/cc-ooc-handler/project.ini
@@ -1,0 +1,4 @@
+[project]
+name = cc-ooc-handler
+type = application
+version = 1.0.0

--- a/projects/cc-ooc-handler/specs/default/cluster-init/files/capacity_check.logrotate
+++ b/projects/cc-ooc-handler/specs/default/cluster-init/files/capacity_check.logrotate
@@ -1,0 +1,9 @@
+/var/log/capacity_check.log {
+    size 100M
+    rotate 5
+    compress
+    delaycompress
+    missingok
+    notifempty
+    copytruncate
+}

--- a/projects/cc-ooc-handler/specs/default/cluster-init/files/capacity_check.md
+++ b/projects/cc-ooc-handler/specs/default/cluster-init/files/capacity_check.md
@@ -1,0 +1,272 @@
+# Capacity Check Script for Slurm with CycleCloud
+
+A bash script to detect and handle out-of-capacity partitions in Slurm with CycleCloud.
+
+## Overview
+
+This script monitors Azure capacity and automatically:
+1. Sets partitions to INACTIVE when capacity failures are detected
+2. Restores partitions to UP when capacity becomes available
+3. Maintains a state file for integration with the job submit Lua plugin
+4. Powers down nodes with CONFIGURING jobs to trigger requeueing
+5. Moves pending jobs from INACTIVE partitions to fallback partitions
+
+## Requirements
+
+- `azslurm` CLI tool (from CycleCloud Slurm integration) OR CycleCloud REST API access
+- `jq` for JSON parsing
+- `curl` (for REST API method)
+- `scontrol` and `squeue` (Slurm commands)
+
+## Features
+
+### Capacity Detection
+- Two methods available: `azslurm buckets` command or CycleCloud REST API
+- The `last_capacity_failure` field indicates capacity issues (number of seconds since last failure)
+- Each node array maps to a single VM size
+- Logs nodearray name, VM type, and capacity failure status for each nodearray
+
+### Capacity Status Retrieval Methods
+
+The script supports two pluggable methods for retrieving capacity status:
+
+**1. azslurm buckets (default):**
+```bash
+azslurm buckets --output-columns nodearray,vm_size,last_capacity_failure --output-format json
+```
+
+**2. CycleCloud REST API:**
+- Uses credentials from `/opt/azurehpc/slurm/autoscale.json`
+- Queries the cluster status endpoint directly
+- Converts `lastCapacityFailure` of `-1.0` to `null` (no failure)
+
+To switch methods, change the function call in `main()` from `get_capacity_status` to `get_capacity_status_rest`.
+
+### Partition State Management
+- If a partition has a capacity failure, set its state to INACTIVE
+- If a partition is INACTIVE and `last_capacity_failure` is null (capacity restored), set its state to UP
+- Only restores partitions that were marked INACTIVE by this script (preserves manual admin changes)
+
+### State File
+- Maintains partition state in `/var/run/slurm/capacity_state.json`
+- Tracks which partitions are INACTIVE due to capacity failures
+- Records timestamp and reason for each state change
+- Used by `job_submit_round_robin.lua` to route jobs to UP partitions only
+
+State file format:
+```json
+{
+  "partitions": {
+    "hpc": {
+      "state": "INACTIVE",
+      "reason": "capacity_failure: 120s ago",
+      "updated": "2026-02-04T10:30:00+00:00"
+    }
+  }
+}
+```
+
+### Pending Job Migration
+- After updating partition states, check all INACTIVE partitions with fallback mappings
+- Power down nodes with CONFIGURING jobs to trigger job requeueing
+- Move pending jobs to the first available UP fallback partition
+- Fallback partitions are defined in an external configuration file
+
+### CONFIGURING Job Handling
+- Jobs in CONFIGURING state are waiting for cloud nodes to power up
+- When a partition is INACTIVE due to capacity failure, these nodes won't start
+- The script uses `power_down_force` to immediately release these nodes
+- This triggers job requeueing, making jobs eligible for migration to fallback partitions
+
+## Configuration
+
+### Partition Mapping Configuration
+
+Partition mappings are defined in `/etc/slurm/partition_config.conf`, which is shared with the `job_submit_round_robin.lua` plugin:
+
+```
+# Partition mapping configuration
+# Format: partition: fallback1,fallback2,fallback3
+
+hpc: hpc,htc,gpu
+htc: htc,hpc,gpu
+gpu: gpu,hpc,htc
+```
+
+This means:
+- Jobs in INACTIVE `hpc` partition will move to `hpc`, `htc`, or `gpu` (first available UP)
+- Jobs in INACTIVE `htc` partition will move to `htc`, `hpc`, or `gpu` (first available UP)
+
+To install the configuration file:
+```bash
+sudo cp partition_config.conf /etc/slurm/partition_config.conf
+```
+
+### State File Location
+
+State file location (can be customized in the script):
+```bash
+STATE_FILE="/var/run/slurm/capacity_state.json"
+```
+
+## Commands Used
+
+Query capacity failures:
+```bash
+azslurm buckets --output-columns nodearray,vm_size,last_capacity_failure --output-format json
+```
+
+Set partition state to INACTIVE:
+```bash
+scontrol update PartitionName=<partition> State=INACTIVE
+```
+
+Set partition state to UP:
+```bash
+scontrol update PartitionName=<partition> State=UP
+```
+
+Move pending job to fallback partition:
+```bash
+scontrol update jobid=<jobid> partition=<fallback>
+```
+
+Get pending jobs in a partition:
+```bash
+squeue -p <partition> -t PENDING -h -o "%i"
+```
+
+Get nodes with CONFIGURING jobs:
+```bash
+squeue -p <partition> -t CONFIGURING -h -o "%N"
+```
+
+Power down a node to trigger job requeue:
+```bash
+scontrol update nodename=<node> state=power_down_force reason="capacity_failure"
+```
+
+## Integration with Job Submit Plugin
+
+The state file is read by `job_submit_round_robin.lua` to:
+- Skip INACTIVE partitions when load balancing
+- Route new jobs only to UP partitions
+- Provide seamless failover without waiting for pending job migration
+
+## Usage
+
+Run manually:
+```bash
+./capacity_check.sh
+```
+
+### Setting up the Cron Job
+
+1. Open the crontab editor:
+   ```bash
+   sudo crontab -e
+   ```
+
+2. Add the following line to run every 5 minutes:
+   ```bash
+   */5 * * * * /opt/azurehpc/slurm/capacity_check.sh >> /var/log/capacity_check.log 2>&1
+   ```
+
+3. Save and exit the editor.
+
+4. Verify the cron job is installed:
+   ```bash
+   sudo crontab -l
+   ```
+
+### Alternative: Systemd Timer
+
+For more control, use a systemd timer instead of cron:
+
+1. Create the service file `/etc/systemd/system/capacity-check.service`:
+   ```ini
+   [Unit]
+   Description=Slurm Capacity Check
+   After=slurmctld.service
+
+   [Service]
+   Type=oneshot
+   ExecStart=/opt/azurehpc/slurm/capacity_check.sh
+   StandardOutput=append:/var/log/capacity_check.log
+   StandardError=append:/var/log/capacity_check.log
+   ```
+
+2. Create the timer file `/etc/systemd/system/capacity-check.timer`:
+   ```ini
+   [Unit]
+   Description=Run Slurm Capacity Check every 5 minutes
+
+   [Timer]
+   OnBootSec=1min
+   OnUnitActiveSec=5min
+
+   [Install]
+   WantedBy=timers.target
+   ```
+
+3. Enable and start the timer:
+   ```bash
+   sudo systemctl daemon-reload
+   sudo systemctl enable capacity-check.timer
+   sudo systemctl start capacity-check.timer
+   ```
+
+4. Check timer status:
+   ```bash
+   sudo systemctl list-timers capacity-check.timer
+   ```
+
+## Logging
+
+The script outputs timestamped log messages including:
+- Capacity failure detection
+- Partition state changes (INACTIVE/UP)
+- State file updates
+- Job migrations
+- Errors
+
+### Log Rotation
+
+To prevent the log file from growing indefinitely, configure logrotate to manage `/var/log/capacity_check.log`.
+
+1. Copy the provided template file or create the logrotate configuration:
+   ```bash
+   sudo cp capacity_check.logrotate /etc/logrotate.d/capacity_check
+   ```
+
+   Or create `/etc/logrotate.d/capacity_check` manually:
+   ```
+   /var/log/capacity_check.log {
+       size 100M
+       rotate 5
+       compress
+       delaycompress
+       missingok
+       notifempty
+       copytruncate
+   }
+   ```
+
+2. Save the file and verify the configuration:
+   ```bash
+   sudo logrotate -d /etc/logrotate.d/capacity_check
+   ```
+
+3. Test the rotation manually (optional):
+   ```bash
+   sudo logrotate -f /etc/logrotate.d/capacity_check
+   ```
+
+Configuration options explained:
+- `size 100M`: Rotate when log reaches 100MB
+- `rotate 5`: Keep up to 5 rotated files
+- `compress`: Compress rotated files with gzip
+- `delaycompress`: Delay compression of the most recent rotated file
+- `missingok`: Don't error if the log file is missing
+- `notifempty`: Don't rotate if the log file is empty
+- `copytruncate`: Truncate the original log file after creating a copy (avoids restarting the service)

--- a/projects/cc-ooc-handler/specs/default/cluster-init/files/capacity_check.md
+++ b/projects/cc-ooc-handler/specs/default/cluster-init/files/capacity_check.md
@@ -30,17 +30,17 @@ This script monitors Azure capacity and automatically:
 
 The script supports two pluggable methods for retrieving capacity status:
 
-**1. azslurm buckets (default):**
-```bash
-azslurm buckets --output-columns nodearray,vm_size,last_capacity_failure --output-format json
-```
-
-**2. CycleCloud REST API:**
+**1. CycleCloud REST API (default):**
 - Uses credentials from `/opt/azurehpc/slurm/autoscale.json`
 - Queries the cluster status endpoint directly
 - Converts `lastCapacityFailure` of `-1.0` to `null` (no failure)
 
-To switch methods, change the function call in `main()` from `get_capacity_status` to `get_capacity_status_rest`.
+**2. azslurm buckets:**
+```bash
+azslurm buckets --output-columns nodearray,vm_size,last_capacity_failure --output-format json
+```
+
+To switch methods, change the function call in `main()` from `get_capacity_status_rest` to `get_capacity_status`.
 
 ### Partition State Management
 - If a partition has a capacity failure, set its state to INACTIVE

--- a/projects/cc-ooc-handler/specs/default/cluster-init/files/capacity_check.sh
+++ b/projects/cc-ooc-handler/specs/default/cluster-init/files/capacity_check.sh
@@ -73,10 +73,15 @@ init_state_file() {
     
     if [[ ! -d "$state_dir" ]]; then
         mkdir -p "$state_dir"
+        chmod 755 "$state_dir"
+        chown slurm:slurm "$state_dir" 2>/dev/null || true
+        log "Created state directory: $state_dir"
     fi
     
     if [[ ! -f "$STATE_FILE" ]]; then
         echo '{"partitions":{}}' > "$STATE_FILE"
+        chmod 644 "$STATE_FILE"
+        chown slurm:slurm "$STATE_FILE" 2>/dev/null || true
         log "Initialized state file: $STATE_FILE"
     fi
 }

--- a/projects/cc-ooc-handler/specs/default/cluster-init/files/capacity_check.sh
+++ b/projects/cc-ooc-handler/specs/default/cluster-init/files/capacity_check.sh
@@ -1,0 +1,356 @@
+#!/bin/bash
+#
+# Capacity Check Script for Slurm with CycleCloud
+#
+# This script detects out-of-capacity partitions and:
+# 1. Sets partitions with capacity failures to INACTIVE
+# 2. Restores partitions to UP when capacity is available
+# 3. Moves pending jobs from INACTIVE partitions to fallback partitions
+#
+# Usage: Run via cron every few minutes
+#   */5 * * * * /path/to/capacity_check.sh >> /var/log/capacity_check.log 2>&1
+#
+
+set -euo pipefail
+
+# Activate the azslurm Python virtual environment
+if [[ -f /opt/azurehpc/slurm/venv/bin/activate ]]; then
+    source /opt/azurehpc/slurm/venv/bin/activate
+else
+    echo "ERROR: azslurm virtual environment not found at /opt/azurehpc/slurm/venv/bin/activate" >&2
+    exit 1
+fi
+
+# Configuration file for partition mappings (shared with job_submit_round_robin.lua)
+PARTITION_CONFIG_FILE="/etc/slurm/partition_config.conf"
+
+# State file to track partition states
+STATE_FILE="/var/run/slurm/capacity_state.json"
+
+# Load partition mappings from external config file
+# Populates FALLBACK_MAPPING associative array
+# Format: partition: fallback1,fallback2,fallback3
+load_partition_mapping() {
+    if [[ ! -f "$PARTITION_CONFIG_FILE" ]]; then
+        log_error "Partition config file not found: $PARTITION_CONFIG_FILE"
+        return 1
+    fi
+    
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        # Remove carriage returns (Windows line endings) and skip comments/empty lines
+        line=$(echo "$line" | tr -d '\r')
+        [[ "$line" =~ ^[[:space:]]*#.*$ || -z "${line// /}" ]] && continue
+        
+        # Parse "partition: fallback1,fallback2,fallback3"
+        local partition fallbacks
+        partition=$(echo "$line" | cut -d: -f1 | tr -d '[:space:]')
+        fallbacks=$(echo "$line" | cut -d: -f2 | tr -d '[:space:]')
+        
+        if [[ -n "$partition" && -n "$fallbacks" ]]; then
+            FALLBACK_MAPPING["$partition"]="$fallbacks"
+            log "Loaded mapping: $partition -> $fallbacks"
+        fi
+    done < "$PARTITION_CONFIG_FILE"
+    
+    log "Loaded ${#FALLBACK_MAPPING[@]} partition mappings from $PARTITION_CONFIG_FILE"
+}
+
+# Fallback partition mappings (populated from config file)
+declare -A FALLBACK_MAPPING
+
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+}
+
+log_error() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] ERROR: $*" >&2
+}
+
+# Initialize state file if it doesn't exist
+init_state_file() {
+    local state_dir
+    state_dir=$(dirname "$STATE_FILE")
+    
+    if [[ ! -d "$state_dir" ]]; then
+        mkdir -p "$state_dir"
+    fi
+    
+    if [[ ! -f "$STATE_FILE" ]]; then
+        echo '{"partitions":{}}' > "$STATE_FILE"
+        log "Initialized state file: $STATE_FILE"
+    fi
+}
+
+# Read partition state from state file
+read_partition_state() {
+    local partition="$1"
+    jq -r --arg p "$partition" '.partitions[$p] // empty' "$STATE_FILE" 2>/dev/null
+}
+
+# Update partition state in state file
+update_state_file() {
+    local partition="$1"
+    local state="$2"
+    local reason="${3:-}"
+    local timestamp
+    timestamp=$(date -Iseconds)
+    
+    local tmp_file="${STATE_FILE}.tmp"
+    
+    jq --arg p "$partition" \
+       --arg s "$state" \
+       --arg r "$reason" \
+       --arg t "$timestamp" \
+       '.partitions[$p] = {"state": $s, "reason": $r, "updated": $t}' \
+       "$STATE_FILE" > "$tmp_file" && mv "$tmp_file" "$STATE_FILE"
+    
+    log "State file updated: $partition -> $state"
+}
+
+# Remove partition from state file (when restored to normal)
+remove_from_state_file() {
+    local partition="$1"
+    local tmp_file="${STATE_FILE}.tmp"
+    
+    jq --arg p "$partition" 'del(.partitions[$p])' "$STATE_FILE" > "$tmp_file" && mv "$tmp_file" "$STATE_FILE"
+    log "State file updated: $partition removed (restored)"
+}
+
+# ============================================================================
+# Capacity Status Retrieval Function
+# ============================================================================
+# This function retrieves capacity status for all nodearrays.
+# Output format: JSON array with objects containing:
+#   - nodearray: name of the nodearray/partition
+#   - last_capacity_failure: seconds since last failure, or null if no failure
+#
+# To use an alternative implementation, replace this function.
+# ============================================================================
+get_capacity_status() {
+    # Default implementation: Use azslurm buckets command
+    local buckets_json
+    if ! buckets_json=$(azslurm buckets --output-columns nodearray,vm_size,last_capacity_failure --output-format json 2>&1); then
+        log_error "Failed to query azslurm buckets: $buckets_json"
+        return 1
+    fi
+    
+    # Normalize output to standard format
+    echo "$buckets_json" | jq '[.[] | {nodearray: .nodearray, vm_type: .vm_size, last_capacity_failure: .last_capacity_failure}]'
+}
+
+# Alternative implementation using CycleCloud REST API
+get_capacity_status_rest() {
+    local autoscale_config="/opt/azurehpc/slurm/autoscale.json"
+    local username password url cluster_name
+    
+    username=$(jq -r '.username' "$autoscale_config")
+    password=$(jq -r '.password' "$autoscale_config")
+    url=$(jq -r '.url' "$autoscale_config")
+    cluster_name=$(jq -r '.cluster_name' "$autoscale_config")
+    
+    local status_json
+    if ! status_json=$(curl -sk -u "$username:$password" "$url/clusters/$cluster_name/status" 2>&1); then
+        log_error "Failed to query CycleCloud API: $status_json"
+        return 1
+    fi
+    
+    # Transform CycleCloud format to standard format
+    # lastCapacityFailure of -1.0 means no failure, convert to null
+    echo "$status_json" | jq '[.nodearrays[] | .name as $name | .buckets[] | {
+        nodearray: $name,
+        vm_type: .definition.machineType,
+        last_capacity_failure: (if .lastCapacityFailure == -1.0 then null else .lastCapacityFailure end)
+    }]'
+}
+
+# Get partition state (UP, DOWN, INACTIVE, etc.)
+get_partition_state() {
+    local partition="$1"
+    scontrol show partition "$partition" 2>/dev/null | grep -oP 'State=\K\w+' || echo "UNKNOWN"
+}
+
+# Check if partition exists
+partition_exists() {
+    local partition="$1"
+    scontrol show partition "$partition" &>/dev/null
+}
+
+# Get first available UP fallback partition
+get_available_fallback() {
+    local partition="$1"
+    local fallbacks="${FALLBACK_MAPPING[$partition]:-}"
+    
+    if [[ -z "$fallbacks" ]]; then
+        log "No fallback mapping defined for partition '$partition'"
+        return 1
+    fi
+    
+    IFS=',' read -ra fallback_list <<< "$fallbacks"
+    for fallback in "${fallback_list[@]}"; do
+        if partition_exists "$fallback"; then
+            local state
+            state=$(get_partition_state "$fallback")
+            if [[ "$state" == "UP" ]]; then
+                echo "$fallback"
+                return 0
+            fi
+        fi
+    done
+    
+    log "No available UP fallback partition found for '$partition'"
+    return 1
+}
+
+# Move pending jobs from a partition to fallback
+move_pending_jobs() {
+    local partition="$1"
+    local fallback="$2"
+    
+    # Get pending jobs in the partition
+    local pending_jobs
+    pending_jobs=$(squeue -p "$partition" -t PENDING -h -o "%i" 2>/dev/null || true)
+    
+    if [[ -z "$pending_jobs" ]]; then
+        log "No pending jobs in partition '$partition'"
+        return 0
+    fi
+    
+    local count=0
+    while IFS= read -r jobid; do
+        if [[ -n "$jobid" ]]; then
+            log "Moving job $jobid from '$partition' to '$fallback'"
+            if scontrol update jobid="$jobid" partition="$fallback" 2>/dev/null; then
+                count=$((count + 1))
+            else
+                log_error "Failed to move job $jobid to partition '$fallback'"
+            fi
+        fi
+    done <<< "$pending_jobs"
+    
+    log "Moved $count pending jobs from '$partition' to '$fallback'"
+}
+
+# Power down nodes with configuring jobs in an INACTIVE partition
+# This triggers job requeueing so jobs can be moved to fallback partitions
+power_down_partition_nodes() {
+    local partition="$1"
+    
+    # Get nodes with jobs in CONFIGURING state (waiting for nodes to power up)
+    local configuring_nodes
+    configuring_nodes=$(squeue -p "$partition" -t CONFIGURING -h -o "%N" 2>/dev/null | tr ',' '\n' | sort -u || true)
+    
+    if [[ -z "$configuring_nodes" ]]; then
+        log "No CONFIGURING jobs in partition '$partition'"
+        return 0
+    fi
+    
+    log "Found nodes with CONFIGURING jobs in partition '$partition'"
+    while IFS= read -r node; do
+        if [[ -n "$node" ]]; then
+            log "Powering down node '$node' to trigger job requeue"
+            if scontrol update nodename="$node" state=power_down_force reason="capacity_failure" 2>/dev/null; then
+                log "Node '$node' set to power_down_force"
+            else
+                log_error "Failed to power down node '$node'"
+            fi
+        fi
+    done <<< "$configuring_nodes"
+}
+
+# Main capacity check logic
+main() {
+    log "Starting capacity check..."
+    
+    # Initialize state file
+    init_state_file
+    
+    # Load partition mappings from config file
+    if ! load_partition_mapping; then
+        log_error "Failed to load partition mappings"
+        exit 1
+    fi
+    
+    # Query capacity status using the pluggable function
+    local capacity_json
+    if ! capacity_json=$(get_capacity_status_rest); then
+        log_error "Failed to retrieve capacity status"
+        exit 1
+    fi
+    
+    # Parse each nodearray entry
+    local nodearrays
+    nodearrays=$(echo "$capacity_json" | jq -r '.[].nodearray' | sort -u)
+    
+    for nodearray in $nodearrays; do
+        # Get the last_capacity_failure and vm_type for this nodearray
+        local last_failure vm_type
+        last_failure=$(echo "$capacity_json" | jq -r --arg na "$nodearray" \
+            '.[] | select(.nodearray == $na) | .last_capacity_failure // empty')
+        vm_type=$(echo "$capacity_json" | jq -r --arg na "$nodearray" \
+            '.[] | select(.nodearray == $na) | .vm_type // "unknown"' | head -1)
+        
+        log "Nodearray '$nodearray': vm_type=$vm_type, last_capacity_failure=$last_failure"
+        
+        local partition="$nodearray"
+        
+        if ! partition_exists "$partition"; then
+            continue
+        fi
+        
+        local current_state
+        current_state=$(get_partition_state "$partition")
+        
+        if [[ -n "$last_failure" && "$last_failure" != "null" ]]; then
+            # Capacity failure detected
+            log "Partition '$partition' has capacity failure (last failure: ${last_failure}s ago)"
+            
+            if [[ "$current_state" != "INACTIVE" ]]; then
+                log "Setting partition '$partition' to INACTIVE"
+                scontrol update PartitionName="$partition" State=INACTIVE
+            fi
+            
+            # Update state file
+            update_state_file "$partition" "INACTIVE" "capacity_failure: ${last_failure}s ago"
+            
+        else
+            # No capacity failure - capacity is available
+            if [[ "$current_state" == "INACTIVE" ]]; then
+                # Check if we marked it INACTIVE (vs manually set)
+                local saved_state
+                saved_state=$(read_partition_state "$partition")
+                if [[ -n "$saved_state" ]]; then
+                    log "Capacity restored for partition '$partition', setting to UP"
+                    scontrol update PartitionName="$partition" State=UP
+                    remove_from_state_file "$partition"
+                else
+                    log "Partition '$partition' is INACTIVE but not tracked by us, skipping"
+                fi
+            fi
+        fi
+    done
+    
+    # Move pending jobs from INACTIVE partitions to fallback partitions
+    log "Checking for pending jobs in INACTIVE partitions..."
+    for partition in "${!FALLBACK_MAPPING[@]}"; do
+        if ! partition_exists "$partition"; then
+            continue
+        fi
+        
+        local state
+        state=$(get_partition_state "$partition")
+        
+        if [[ "$state" == "INACTIVE" ]]; then
+            # Power down nodes with configuring jobs and requeue running jobs
+            power_down_partition_nodes "$partition"
+            
+            local fallback
+            if fallback=$(get_available_fallback "$partition"); then
+                move_pending_jobs "$partition" "$fallback"
+            fi
+        fi
+    done
+    
+    log "Capacity check complete"
+}
+
+main "$@"

--- a/projects/cc-ooc-handler/specs/default/cluster-init/files/common.sh
+++ b/projects/cc-ooc-handler/specs/default/cluster-init/files/common.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Common functions for OOC Handler installation scripts
+# This script provides shared logging and utility functions
+
+# Default log file (can be overridden before sourcing)
+LOG_FILE="${LOG_FILE:-/var/log/cc-ooc-handler-install.log}"
+
+# Logging function to prefix messages with timestamp
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOG_FILE"
+}
+
+# Debug logging function (only logs if DEBUG_LOGGING is true)
+debug_log() {
+    if [ "${DEBUG_LOGGING:-false}" = "true" ]; then
+        log "DEBUG: $*"
+    fi
+}
+
+# Error handler function
+error_exit() {
+    log "ERROR: $1"
+    exit 1
+}
+
+# Check if this is the scheduler node by verifying slurmctld service exists
+check_scheduler_node() {
+    if ! systemctl list-unit-files slurmctld.service &>/dev/null || ! systemctl list-unit-files slurmctld.service | grep -q slurmctld; then
+        echo "ERROR: slurmctld service not found. This script can only be executed on the scheduler node."
+        exit 1
+    fi
+}
+
+# Load configuration from environment file if it exists
+# Usage: load_configuration "$SCRIPT_DIR"
+load_base_configuration() {
+    local script_dir="$1"
+    local config_file="$script_dir/../files/ooc-handler-config.env"
+    
+    if [ -f "$config_file" ]; then
+        log "Loading configuration from $config_file"
+        source "$config_file"
+    else
+        log "Configuration file $config_file not found, using defaults"
+    fi
+    
+    # Set defaults for common configuration variables
+    DEBUG_LOGGING="${DEBUG_LOGGING:-false}"
+}

--- a/projects/cc-ooc-handler/specs/default/cluster-init/files/job_round_robin.md
+++ b/projects/cc-ooc-handler/specs/default/cluster-init/files/job_round_robin.md
@@ -1,0 +1,200 @@
+# Load-Balanced Partition Assignment for Slurm
+
+A LUA job submission plugin that maps logical partitions to a set of actual partitions and load balances across them.
+
+## Overview
+
+This plugin allows users to submit jobs to a "logical" partition (e.g., `hpc`) which is then automatically mapped and load balanced across multiple actual partitions (e.g., `hpc_1`, `hpc_2`, `hpc_3`).
+
+**Key features:**
+- **Partition mapping** - Define logical partitions that map to multiple actual partitions
+- **Load balancing** - Jobs are assigned to the least loaded partition in the mapping
+- **Capacity-aware** - Integrates with `capacity_check.sh` to skip INACTIVE partitions
+- **Transparent to users** - Users submit to familiar partition names
+
+**Balancing strategies:**
+- **By job count** - Balance based on total number of jobs
+- **By node count** - Balance based on total nodes allocated to jobs
+
+**Job states counted:**
+- `pending` - Jobs waiting in the queue
+- `running` - Jobs currently executing
+- `configuring` - Jobs waiting for nodes to start (e.g., cloud nodes powering up)
+
+## Files
+
+- `job_submit_round_robin.lua` - The Lua plugin script
+- `job_submit_prompt.md` - Prompt template for generating similar scripts
+- `partition_config.conf` - External configuration file for partition mappings
+- `capacity_check.sh` - Script that maintains partition state file
+- `capacity_check.md` - Documentation for capacity check script
+
+## Installation
+
+1. Copy the plugin to your Slurm configuration directory:
+   ```bash
+   sudo cp job_submit_round_robin.lua /etc/slurm/job_submit.lua
+   ```
+
+2. Copy the partition configuration file:
+   ```bash
+   sudo cp partition_config.conf /etc/slurm/partition_config.conf
+   ```
+
+3. Edit `/etc/slurm/slurm.conf` and add:
+   ```
+   JobSubmitPlugins=lua
+   ```
+
+4. Restart the Slurm controller:
+   ```bash
+   sudo systemctl restart slurmctld
+   ```
+
+## Configuration
+
+Edit `/etc/slurm/partition_config.conf` to define your partition mappings:
+
+```
+# Partition mapping configuration
+# Format: partition: fallback1,fallback2,fallback3
+
+hpc: hpc_1,hpc_2,hpc_3
+htc: htc_1,htc_2
+```
+
+This means:
+- Jobs submitted to `hpc` will be load balanced across `hpc_1`, `hpc_2`, `hpc_3`
+- Jobs submitted to `htc` will be load balanced across `htc_1`, `htc_2`
+- Jobs submitted to any other partition (e.g., `gpu`) will keep their original partition
+
+## How It Works
+
+1. User submits a job with `-p hpc`
+2. Plugin looks up `hpc` in `PARTITION_MAPPING`
+3. Finds target partitions: `{"hpc_1", "hpc_2", "hpc_3"}`
+4. Queries load (jobs or nodes) for each target partition via `squeue`
+5. Assigns job to the least loaded partition (e.g., `hpc_2`)
+
+## Balancing Methods
+
+### By Job Count (`get_least_loaded_partition_byjob`)
+Counts total jobs (pending + running + configuring) per partition.
+
+```bash
+squeue -p <partition> -h -t pending,running,configuring | wc -l
+```
+
+### By Node Count (`get_least_loaded_partition_bynode`)
+Sums nodes allocated to all jobs per partition.
+
+```bash
+squeue -p <partition> -h -t pending,running,configuring -o '%D' | awk '{sum+=$1} END {print sum+0}'
+```
+
+## squeue Options Reference
+
+| Option | Description |
+|--------|-------------|
+| `-p <partition>` | Filter by partition name |
+| `-h` | Omit header line |
+| `-t pending,running,configuring` | Filter by job states |
+| `-o '%D'` | Output only node count |
+| `wc -l` | Count lines (jobs) |
+
+## Behavior
+
+- Jobs submitted to a mapped partition are load balanced across target partitions
+- Jobs submitted to unmapped partitions keep their original partition
+- **INACTIVE partitions are skipped** (based on state file from `capacity_check.sh`)
+- When all target partitions have 0 load, the first active partition is used
+- When all target partitions are INACTIVE, the original partition is kept
+- On error querying a partition, it is deprioritized (assigned high count)
+
+## Integration with capacity_check.sh
+
+Both the Lua plugin and `capacity_check.sh` share the same configuration file (`/etc/slurm/partition_config.conf`) for partition mappings. The plugin also reads partition state from `/var/run/slurm/capacity_state.json`, which is maintained by `capacity_check.sh`.
+
+This allows the system to:
+- Skip partitions that are INACTIVE due to capacity failures
+- Route jobs only to UP partitions
+- Provide seamless failover without external intervention
+- Automatically power down nodes with CONFIGURING jobs when capacity fails
+- Move pending jobs from INACTIVE partitions to fallback partitions
+
+State file format:
+```json
+{
+  "partitions": {
+    "hpc": {
+      "state": "INACTIVE",
+      "reason": "capacity_failure: 120s ago",
+      "updated": "2026-02-04T10:30:00+00:00"
+    }
+  }
+}
+```
+
+To enable capacity-aware load balancing:
+1. Install partition config: `sudo cp partition_config.conf /etc/slurm/partition_config.conf`
+2. Configure and run `capacity_check.sh` via cron
+3. Ensure the state file path matches in both scripts (`/var/run/slurm/capacity_state.json`)
+
+## Example
+
+```bash
+# Configuration in /etc/slurm/partition_config.conf:
+# hpc: hpc_1,hpc_2,hpc_3
+# htc: htc_1,htc_2
+
+# Scenario 1: Load balance across HPC partitions
+# Assume: hpc_1=5 nodes, hpc_2=2 nodes, hpc_3=8 nodes
+sbatch -p hpc job1.slurm  # -> hpc_2 (2 nodes, least loaded)
+sbatch -p hpc job2.slurm  # -> hpc_2 (still least loaded)
+
+# Scenario 2: Load balance across HTC partitions
+# Assume: htc_1=3 nodes, htc_2=1 node
+sbatch -p htc job3.slurm  # -> htc_2 (1 node, least loaded)
+
+# Scenario 3: Unmapped partition
+sbatch -p gpu job4.slurm  # -> gpu (no mapping, unchanged)
+
+# Scenario 4: All target partitions empty
+# Assume: hpc_1=0, hpc_2=0, hpc_3=0
+sbatch -p hpc job5.slurm  # -> hpc_1 (first in list)
+
+# Scenario 5: Some partitions INACTIVE (capacity issue)
+# Assume: hpc_1=INACTIVE, hpc_2=UP (2 nodes), hpc_3=UP (5 nodes)
+sbatch -p hpc job6.slurm  # -> hpc_2 (hpc_1 skipped, hpc_2 least loaded)
+
+# Scenario 6: All target partitions INACTIVE
+# Assume: hpc_1=INACTIVE, hpc_2=INACTIVE, hpc_3=INACTIVE
+sbatch -p hpc job7.slurm  # -> hpc (original kept)
+```
+
+## Troubleshooting
+
+Check the Slurm controller logs for plugin messages:
+```bash
+sudo journalctl -u slurmctld | grep -i load-balance
+```
+
+Example log messages:
+```
+Load-balance: Assigning job 'myjob' from user 1000: 'hpc' -> 'hpc_2'
+Partition 'gpu' has no load-balance mapping, keeping original for user 1000
+All target partitions for 'hpc' have 0 allocated nodes, using 'hpc_1'
+Partition 'hpc_1' is INACTIVE (capacity issue), skipping
+No active target partitions for 'hpc', keeping original for user 1000
+```
+
+## Slurm Lua API Reference
+
+- `slurm.log_info(format, ...)` - Log info level message
+- `slurm.log_debug(format, ...)` - Log debug level message
+- `slurm.log_error(format, ...)` - Log error level message
+- `slurm.SUCCESS` - Return value for successful job submission
+- `slurm.FAILURE` - Return value to reject job submission
+- `io.popen(cmd)` - Execute shell command and read output
+
+**Note:** `slurm.get_partition_info()` is not available in all Slurm versions, so this plugin uses `squeue` via `io.popen()` for compatibility.

--- a/projects/cc-ooc-handler/specs/default/cluster-init/files/job_submit_round_robin.lua
+++ b/projects/cc-ooc-handler/specs/default/cluster-init/files/job_submit_round_robin.lua
@@ -1,0 +1,302 @@
+--[[
+    Slurm Job Submit Plugin - Load-Balanced Partition Assignment
+    
+    This LUA script assigns jobs to partitions based on current job count.
+    When a job specifies a partition that has a mapping defined, it load balances
+    across the mapped partitions (e.g., "hpc" -> {"hpc_1", "hpc_2", "hpc_3"}).
+    Uses squeue to query job counts.
+
+    Installation:
+    1. Copy this file to /etc/slurm/job_submit.lua
+    2. Copy partition_config.json to /etc/slurm/partition_config.json
+    3. Add to slurm.conf: JobSubmitPlugins=lua
+    4. Restart slurmctld: systemctl restart slurmctld
+
+    Configuration:
+    - Edit /etc/slurm/partition_config.json to define partition mappings
+--]]
+
+-- Path to external partition configuration file (shared with capacity_check.sh)
+PARTITION_CONFIG_FILE = "/etc/slurm/partition_config.conf"
+
+-- Partition mapping table (loaded from config file)
+PARTITION_MAPPING = {}
+
+-- Slurm log levels
+SLURM_ERROR = 0
+SLURM_INFO = 6
+SLURM_DEBUG = 7
+
+-- Path to partition state file maintained by capacity_check.sh
+PARTITION_STATE_FILE = "/var/run/slurm/capacity_state.json"
+
+--[[
+    Load partition mappings from config file.
+    Format: partition: fallback1,fallback2,fallback3
+    Lines starting with # are comments, empty lines are ignored.
+--]]
+function load_partition_config()
+    local file = io.open(PARTITION_CONFIG_FILE, "r")
+    if file == nil then
+        slurm.log_error("Failed to open partition config file: %s", PARTITION_CONFIG_FILE)
+        return false
+    end
+    
+    for line in file:lines() do
+        -- Remove carriage returns (Windows line endings)
+        line = string.gsub(line, "\r", "")
+        -- Skip comments and empty lines
+        if not string.match(line, "^%s*#") and not string.match(line, "^%s*$") then
+            -- Parse "partition: fallback1,fallback2,fallback3"
+            local partition, fallbacks = string.match(line, "^%s*([^:]+)%s*:%s*(.+)%s*$")
+            if partition and fallbacks then
+                partition = string.gsub(partition, "^%s*(.-)%s*$", "%1")  -- trim
+                local partitions = {}
+                for part in string.gmatch(fallbacks, "([^,]+)") do
+                    part = string.gsub(part, "^%s*(.-)%s*$", "%1")  -- trim
+                    table.insert(partitions, part)
+                end
+                if #partitions > 0 then
+                    PARTITION_MAPPING[partition] = partitions
+                    slurm.log_debug("Loaded partition mapping: %s -> %d targets", partition, #partitions)
+                end
+            end
+        end
+    end
+    
+    file:close()
+    slurm.log_info("Loaded partition mappings from %s", PARTITION_CONFIG_FILE)
+    return true
+end
+
+-- Load partition config at plugin initialization
+load_partition_config()
+
+--[[
+    Get the list of target partitions for a given partition.
+    Returns the mapped partitions if a mapping exists, nil otherwise.
+--]]
+function get_partition_targets(partition_name)
+    if partition_name == nil then
+        return nil
+    end
+    return PARTITION_MAPPING[partition_name]
+end
+
+--[[
+    Check if a partition is marked as INACTIVE in the state file.
+    The state file is maintained by capacity_check.sh and tracks partitions
+    that are INACTIVE due to capacity failures.
+    Returns true if partition is INACTIVE, false otherwise.
+--]]
+function is_partition_inactive(partition_name)
+    local file = io.open(PARTITION_STATE_FILE, "r")
+    if file == nil then
+        -- State file doesn't exist, assume all partitions are UP
+        return false
+    end
+    
+    local content = file:read("*a")
+    file:close()
+    
+    if content == nil or content == "" then
+        return false
+    end
+    
+    -- Simple pattern matching to check if partition is in the state file
+    -- Looking for: "partition_name": {"state": "INACTIVE"
+    local pattern = '"' .. partition_name .. '":%s*{[^}]*"state":%s*"INACTIVE"'
+    if string.match(content, pattern) then
+        slurm.log_debug("Partition '%s' is marked INACTIVE in state file", partition_name)
+        return true
+    end
+    
+    return false
+end
+
+--[[
+    Filter target partitions to only include those that are UP (not INACTIVE).
+    Uses the state file maintained by capacity_check.sh.
+    Returns a table of active partitions.
+--]]
+function get_active_partitions(target_partitions)
+    local active = {}
+    for _, partition in ipairs(target_partitions) do
+        if not is_partition_inactive(partition) then
+            table.insert(active, partition)
+        else
+            slurm.log_info("Partition '%s' is INACTIVE (capacity issue), skipping", partition)
+        end
+    end
+    return active
+end
+
+--[[
+    Get the total job count for a partition using squeue.
+    Returns the total number of jobs (pending, running, or configuring) in the partition.
+    Configuring state includes jobs waiting for nodes to start.
+--]]
+function get_partition_job_count(partition_name)
+    -- Use full path as PATH may be limited in slurmctld context
+    local cmd = string.format("/usr/bin/squeue -p %s -h -t pending,running,configuring 2>/dev/null | wc -l", partition_name)
+    local handle = io.popen(cmd)
+    
+    if handle == nil then
+        slurm.log_error("Failed to execute squeue for partition %s", partition_name)
+        return 999999  -- Return high count on error to deprioritize
+    end
+    
+    local result = handle:read("*a")
+    handle:close()
+    
+    local total_jobs = tonumber(result) or 0
+    slurm.log_debug("Partition '%s': %d total jobs", partition_name, total_jobs)
+    return total_jobs
+end
+
+--[[
+    Get the partition with the least number of total jobs from a list of target partitions.
+    Returns the partition name with the lowest job count.
+    If all partitions have 0 jobs, returns the first partition in the list.
+--]]
+function get_least_loaded_partition_byjob(target_partitions, original_partition)
+    local min_jobs = nil
+    local min_partition = target_partitions[1]
+    local all_zero = true
+    
+    for _, partition in ipairs(target_partitions) do
+        local jobs = get_partition_job_count(partition)
+        
+        if jobs > 0 then
+            all_zero = false
+        end
+        
+        if min_jobs == nil or jobs < min_jobs then
+            min_jobs = jobs
+            min_partition = partition
+        end
+    end
+    
+    -- If all partitions have 0 jobs, return first target partition
+    if all_zero then
+        slurm.log_info("All target partitions for '%s' have 0 jobs, using '%s'", 
+                       original_partition or "(default)", min_partition)
+        return min_partition
+    end
+    
+    slurm.log_info("Least loaded partition (by job count) for '%s': '%s' with %d total jobs", 
+                   original_partition or "(default)", min_partition, min_jobs or 0)
+    return min_partition
+end
+
+--[[
+    Get the total allocated nodes for a partition using squeue.
+    Returns the sum of nodes allocated to all jobs (pending, running, or configuring).
+--]]
+function get_partition_allocated_nodes(partition_name)
+    -- Use full path as PATH may be limited in slurmctld context
+    local cmd = string.format("/usr/bin/squeue -p %s -h -t pending,running,configuring -o '%%D' 2>/dev/null | awk '{sum+=$1} END {print sum+0}'", partition_name)
+    local handle = io.popen(cmd)
+    
+    if handle == nil then
+        slurm.log_error("Failed to execute squeue for partition %s", partition_name)
+        return 999999  -- Return high count on error to deprioritize
+    end
+    
+    local result = handle:read("*a")
+    handle:close()
+    
+    local total_nodes = tonumber(result) or 0
+    slurm.log_debug("Partition '%s': %d allocated nodes", partition_name, total_nodes)
+    return total_nodes
+end
+
+--[[
+    Get the partition with the least number of allocated nodes from a list of target partitions.
+    Returns the partition name with the lowest node allocation.
+    If all partitions have 0 nodes, returns the first partition in the list.
+--]]
+function get_least_loaded_partition_bynode(target_partitions, original_partition)
+    local min_nodes = nil
+    local min_partition = target_partitions[1]
+    local all_zero = true
+    
+    for _, partition in ipairs(target_partitions) do
+        local nodes = get_partition_allocated_nodes(partition)
+        
+        if nodes > 0 then
+            all_zero = false
+        end
+        
+        if min_nodes == nil or nodes < min_nodes then
+            min_nodes = nodes
+            min_partition = partition
+        end
+    end
+    
+    -- If all partitions have 0 allocated nodes, return first target partition
+    if all_zero then
+        slurm.log_info("All target partitions for '%s' have 0 allocated nodes, using '%s'", 
+                       original_partition or "(default)", min_partition)
+        return min_partition
+    end
+    
+    slurm.log_info("Least loaded partition (by node count) for '%s': '%s' with %d allocated nodes", 
+                   original_partition or "(default)", min_partition, min_nodes or 0)
+    return min_partition
+end
+
+--[[
+    Main job_submit function called by Slurm for each job submission.
+    
+    Arguments:
+        job_desc   - Job descriptor table (modifiable)
+        part_list  - List of partitions (modifiable)
+        submit_uid - UID of the submitting user
+    
+    Returns:
+        slurm.SUCCESS - Job submission proceeds
+        slurm.FAILURE - Job submission is rejected
+        slurm.ERROR   - An error occurred
+--]]
+function slurm_job_submit(job_desc, part_list, submit_uid)
+    -- Get the target partitions for the requested partition
+    local target_partitions = get_partition_targets(job_desc.partition)
+    
+    -- If no mapping exists for this partition, keep original and skip load balancing
+    if target_partitions == nil then
+        slurm.log_info("Partition '%s' has no load-balance mapping, keeping original for user %d", 
+                       job_desc.partition or "(default)", submit_uid)
+        return slurm.SUCCESS
+    end
+    
+    -- Filter to only active partitions (not marked INACTIVE in state file)
+    local active_partitions = get_active_partitions(target_partitions)
+    
+    -- If no active partitions, keep original partition
+    if #active_partitions == 0 then
+        slurm.log_info("No active target partitions for '%s', keeping original for user %d", 
+                       job_desc.partition or "(default)", submit_uid)
+        return slurm.SUCCESS
+    end
+    
+    -- Get the least loaded partition by node count from the active target partitions
+    local partition = get_least_loaded_partition_bynode(active_partitions, job_desc.partition)
+    
+    -- Update partition to the least loaded target
+    slurm.log_info("Load-balance: Assigning job '%s' from user %d: '%s' -> '%s'", 
+                   job_desc.name or "(unnamed)", submit_uid, job_desc.partition, partition)
+    job_desc.partition = partition
+    
+    return slurm.SUCCESS
+end
+
+--[[
+    Job modify function - called when jobs are modified.
+    We don't alter partition assignments on job modifications.
+--]]
+function slurm_job_modify(job_desc, job_rec, part_list, modify_uid)
+    return slurm.SUCCESS
+end
+
+slurm.log_info("Load-balanced job submit plugin loaded with partition mappings")

--- a/projects/cc-ooc-handler/specs/default/cluster-init/files/job_submit_round_robin.lua
+++ b/projects/cc-ooc-handler/specs/default/cluster-init/files/job_submit_round_robin.lua
@@ -8,12 +8,12 @@
 
     Installation:
     1. Copy this file to /etc/slurm/job_submit.lua
-    2. Copy partition_config.json to /etc/slurm/partition_config.json
+    2. Copy partition_config.conf to /etc/slurm/partition_config.conf
     3. Add to slurm.conf: JobSubmitPlugins=lua
     4. Restart slurmctld: systemctl restart slurmctld
 
     Configuration:
-    - Edit /etc/slurm/partition_config.json to define partition mappings
+    - Edit /etc/slurm/partition_config.conf to define partition mappings
 --]]
 
 -- Path to external partition configuration file (shared with capacity_check.sh)

--- a/projects/cc-ooc-handler/specs/default/cluster-init/files/job_submit_round_robin.lua
+++ b/projects/cc-ooc-handler/specs/default/cluster-init/files/job_submit_round_robin.lua
@@ -84,11 +84,12 @@ function get_partition_targets(partition_name)
 end
 
 --[[
-    Read and parse the partition state file.
+    Read the partition state file.
     The state file is maintained by capacity_check.sh and tracks partitions
     that are INACTIVE due to capacity failures.
     Returns the file content as a string, or nil if the file doesn't exist or is empty.
     This should be called once per job submission to avoid repeated I/O.
+    The content is then passed to is_partition_inactive() for pattern matching.
 --]]
 function read_partition_state()
     local file = io.open(PARTITION_STATE_FILE, "r")

--- a/projects/cc-ooc-handler/specs/default/cluster-init/files/ooc-handler-config.env
+++ b/projects/cc-ooc-handler/specs/default/cluster-init/files/ooc-handler-config.env
@@ -1,0 +1,24 @@
+# OOC Handler Configuration
+# Environment variables for the Slurm OOC handler components
+# These values can be overridden by CycleCloud cluster parameters
+
+# =============================================================================
+# General Settings
+# =============================================================================
+
+# Enable debug logging for installation scripts
+DEBUG_LOGGING="${DEBUG_LOGGING:-false}"
+
+# Slurm configuration paths (usually auto-detected)
+# SLURM_CONFIG_DIR="/etc/slurm"
+# SLURM_STATE_DIR="/var/run/slurm"
+
+# =============================================================================
+# Capacity Check Service Settings
+# =============================================================================
+
+# Interval in seconds between capacity checks (default: 300 = 5 minutes)
+CAPACITY_CHECK_INTERVAL="${CAPACITY_CHECK_INTERVAL:-300}"
+
+# Installation directory for capacity check script (must already exist)
+# INSTALL_DIR="/opt/azurehpc/slurm"

--- a/projects/cc-ooc-handler/specs/default/cluster-init/files/ooc-handler-config.env
+++ b/projects/cc-ooc-handler/specs/default/cluster-init/files/ooc-handler-config.env
@@ -17,8 +17,8 @@ DEBUG_LOGGING="${DEBUG_LOGGING:-false}"
 # Capacity Check Service Settings
 # =============================================================================
 
-# Interval in seconds between capacity checks (default: 300 = 5 minutes)
-CAPACITY_CHECK_INTERVAL="${CAPACITY_CHECK_INTERVAL:-300}"
+# Cron schedule for capacity checks (default: every 6 minutes)
+CAPACITY_CHECK_CRON="${CAPACITY_CHECK_CRON:-*/6 * * * *}"
 
 # Installation directory for capacity check script (must already exist)
 # INSTALL_DIR="/opt/azurehpc/slurm"

--- a/projects/cc-ooc-handler/specs/default/cluster-init/files/partition_config.conf
+++ b/projects/cc-ooc-handler/specs/default/cluster-init/files/partition_config.conf
@@ -1,0 +1,8 @@
+# Partition mapping configuration
+# Format: partition: fallback1,fallback2,fallback3
+# Lines starting with # are comments
+# Empty lines are ignored
+
+hpc: hpc,htc,gpu
+htc: htc,hpc,gpu
+gpu: gpu,hpc,htc

--- a/projects/cc-ooc-handler/specs/default/cluster-init/scripts/00_install_job_plugin.sh
+++ b/projects/cc-ooc-handler/specs/default/cluster-init/scripts/00_install_job_plugin.sh
@@ -1,0 +1,241 @@
+#!/bin/bash
+# Slurm job_submit Plugin Installation Script
+# This script installs and configures the job_submit Lua plugin for Slurm
+# to handle out-of-capacity (OOC) scenarios on CycleCloud clusters
+# using load-balanced partition assignment
+
+set -euo pipefail
+
+# Global variables
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+LOG_FILE="/var/log/cc-ooc-handler-install.log"
+SLURM_CONFIG_DIR="/etc/slurm"
+SLURM_STATE_DIR="/var/run/slurm"
+PLUGIN_SOURCE="job_submit_round_robin.lua"
+PLUGIN_DEST="job_submit.lua"
+
+# Source common functions
+source "$SCRIPT_DIR/../files/common.sh"
+
+# Check if this is the scheduler node
+check_scheduler_node
+
+# Load configuration from environment file if it exists
+load_configuration() {
+    load_base_configuration "$SCRIPT_DIR"
+    
+    # Slurm configuration paths
+    SLURM_CONFIG_DIR="${SLURM_CONFIG_DIR:-/etc/slurm}"
+    SLURM_STATE_DIR="${SLURM_STATE_DIR:-/var/run/slurm}"
+    
+    log "Configuration loaded:"
+    log "  Slurm config dir: $SLURM_CONFIG_DIR"
+    log "  Slurm state dir: $SLURM_STATE_DIR"
+}
+
+# Create required directories
+setup_directories() {
+    log "Setting up directories..."
+    
+    mkdir -p "$SLURM_CONFIG_DIR"
+    chmod 755 "$SLURM_CONFIG_DIR"
+    
+    mkdir -p "$SLURM_STATE_DIR"
+    chmod 755 "$SLURM_STATE_DIR"
+    chown slurm:slurm "$SLURM_STATE_DIR" 2>/dev/null || true
+    
+    log "Created directories: $SLURM_CONFIG_DIR, $SLURM_STATE_DIR"
+}
+
+# Install the job_submit Lua plugin
+install_plugin() {
+    log "Installing job_submit Lua plugin..."
+    
+    local plugin_source="$SCRIPT_DIR/../files/$PLUGIN_SOURCE"
+    local plugin_dest="$SLURM_CONFIG_DIR/$PLUGIN_DEST"
+    
+    if [ -f "$plugin_source" ]; then
+        cp "$plugin_source" "$plugin_dest"
+        chmod 644 "$plugin_dest"
+        log "Installed plugin from $plugin_source to $plugin_dest"
+    else
+        error_exit "Plugin source file not found at $plugin_source"
+    fi
+}
+
+# Create the partition configuration file if it doesn't exist
+create_partition_config() {
+    log "Setting up partition configuration..."
+    
+    local config_dest="$SLURM_CONFIG_DIR/partition_config.conf"
+    local config_source="$SCRIPT_DIR/../files/partition_config.conf"
+    
+    # If a config file is provided, use it
+    if [ -f "$config_source" ]; then
+        cp "$config_source" "$config_dest"
+        chmod 644 "$config_dest"
+        log "Installed partition config from $config_source to $config_dest"
+        return 0
+    fi
+    
+    # If config already exists, don't overwrite
+    if [ -f "$config_dest" ]; then
+        log "Partition configuration already exists at $config_dest"
+        return 0
+    fi
+    
+    # Create sample configuration
+    cat > "$config_dest" << 'EOF'
+# Partition Configuration for Load-Balanced Job Submission
+# Format: partition: fallback1,fallback2,fallback3
+# 
+# When a job is submitted to a partition listed here, the plugin will
+# load-balance across the specified fallback partitions based on
+# current node allocation.
+#
+# Example:
+# hpc: hpc_eastus,hpc_westus,hpc_northeu
+# gpu: gpu_eastus,gpu_westus
+#
+# Lines starting with # are comments, empty lines are ignored.
+
+EOF
+
+    chmod 644 "$config_dest"
+    log "Created sample partition configuration at $config_dest"
+    log "Edit this file to define partition mappings for load balancing"
+}
+
+# Configure Slurm to use the job_submit plugin
+configure_slurm() {
+    log "Configuring Slurm to use job_submit plugin..."
+    
+    local slurm_conf="$SLURM_CONFIG_DIR/slurm.conf"
+    local plugin_path="$SLURM_CONFIG_DIR/$PLUGIN_DEST"
+    
+    if [ ! -f "$slurm_conf" ]; then
+        log "WARNING: slurm.conf not found at $slurm_conf"
+        log "Manual configuration required. Add to slurm.conf:"
+        log "  JobSubmitPlugins=lua"
+        return 0
+    fi
+    
+    # Check if JobSubmitPlugins is already configured
+    if grep -q "^JobSubmitPlugins=" "$slurm_conf"; then
+        local current_plugins
+        current_plugins=$(grep "^JobSubmitPlugins=" "$slurm_conf" | cut -d'=' -f2)
+        
+        if echo "$current_plugins" | grep -q "lua"; then
+            log "JobSubmitPlugins already includes 'lua'"
+        else
+            log "WARNING: JobSubmitPlugins is configured but does not include 'lua'"
+            log "Current setting: JobSubmitPlugins=$current_plugins"
+            log "Please add 'lua' to the JobSubmitPlugins configuration"
+        fi
+    else
+        log "Adding JobSubmitPlugins=lua to slurm.conf"
+        echo "" >> "$slurm_conf"
+        echo "# Added by cc-ooc-handler" >> "$slurm_conf"
+        echo "JobSubmitPlugins=lua" >> "$slurm_conf"
+    fi
+    
+    log "Slurm configuration updated"
+}
+
+# Validate the installation
+validate_installation() {
+    log "Validating installation..."
+    
+    local validation_passed=true
+    local plugin_path="$SLURM_CONFIG_DIR/$PLUGIN_DEST"
+    local config_path="$SLURM_CONFIG_DIR/partition_config.conf"
+    
+    # Check plugin file
+    if [ -f "$plugin_path" ]; then
+        log "  ✓ Plugin file exists: $plugin_path"
+    else
+        log "  ✗ Plugin file missing"
+        validation_passed=false
+    fi
+    
+    # Check partition config file
+    if [ -f "$config_path" ]; then
+        log "  ✓ Partition configuration exists: $config_path"
+    else
+        log "  ✗ Partition configuration missing"
+        validation_passed=false
+    fi
+    
+    # Check state directory
+    if [ -d "$SLURM_STATE_DIR" ]; then
+        log "  ✓ State directory exists: $SLURM_STATE_DIR"
+    else
+        log "  ✗ State directory missing"
+        validation_passed=false
+    fi
+    
+    # Check slurm.conf for JobSubmitPlugins
+    if [ -f "$SLURM_CONFIG_DIR/slurm.conf" ]; then
+        if grep -q "JobSubmitPlugins=.*lua" "$SLURM_CONFIG_DIR/slurm.conf"; then
+            log "  ✓ Slurm configured to use lua plugin"
+        else
+            log "  ✗ Slurm not configured for lua plugin"
+            validation_passed=false
+        fi
+    else
+        log "  - slurm.conf not found, skipping configuration check"
+    fi
+    
+    if [ "$validation_passed" = true ]; then
+        log "Validation completed successfully"
+    else
+        log "Validation completed with warnings"
+    fi
+}
+
+# Print usage instructions
+print_usage() {
+    log ""
+    log "=========================================="
+    log "OOC Handler Installation Complete"
+    log "=========================================="
+    log ""
+    log "Plugin location: $SLURM_CONFIG_DIR/$PLUGIN_DEST"
+    log "Partition config: $SLURM_CONFIG_DIR/partition_config.conf"
+    log "State directory: $SLURM_STATE_DIR"
+    log ""
+    log "To configure partition load balancing, edit:"
+    log "  $SLURM_CONFIG_DIR/partition_config.conf"
+    log ""
+    log "To apply changes, restart slurmctld:"
+    log "  systemctl restart slurmctld"
+    log ""
+    log "To verify the plugin is loaded:"
+    log "  scontrol show config | grep JobSubmitPlugins"
+    log ""
+}
+
+# Main function
+main() {
+    log "=========================================="
+    log "OOC Handler Installation Script"
+    log "=========================================="
+    
+    # Ensure running as root
+    if [ "$(id -u)" -ne 0 ]; then
+        error_exit "This script must be run as root"
+    fi
+    
+    load_configuration
+    setup_directories
+    install_plugin
+    create_partition_config
+    configure_slurm
+    validate_installation
+    print_usage
+    
+    log "OOC Handler installation completed successfully"
+}
+
+# Run main function
+main "$@"

--- a/projects/cc-ooc-handler/specs/default/cluster-init/scripts/00_install_job_plugin.sh
+++ b/projects/cc-ooc-handler/specs/default/cluster-init/scripts/00_install_job_plugin.sh
@@ -71,7 +71,7 @@ create_partition_config() {
     local config_sample="$SLURM_CONFIG_DIR/partition_config.conf.sample"
     local config_source="$SCRIPT_DIR/../files/partition_config.conf"
     
-    # If a config file is provided, install it as .sample (always update the sample)
+    # If a config file is provided, install it as .sample (update the sample with shipped config)
     if [ -f "$config_source" ]; then
         cp "$config_source" "$config_sample"
         chmod 644 "$config_sample"

--- a/projects/cc-ooc-handler/specs/default/cluster-init/scripts/00_install_job_plugin.sh
+++ b/projects/cc-ooc-handler/specs/default/cluster-init/scripts/00_install_job_plugin.sh
@@ -68,23 +68,31 @@ create_partition_config() {
     log "Setting up partition configuration..."
     
     local config_dest="$SLURM_CONFIG_DIR/partition_config.conf"
+    local config_sample="$SLURM_CONFIG_DIR/partition_config.conf.sample"
     local config_source="$SCRIPT_DIR/../files/partition_config.conf"
     
-    # If a config file is provided, use it
+    # If a config file is provided, install it as .sample (always update the sample)
     if [ -f "$config_source" ]; then
-        cp "$config_source" "$config_dest"
-        chmod 644 "$config_dest"
-        log "Installed partition config from $config_source to $config_dest"
-        return 0
+        cp "$config_source" "$config_sample"
+        chmod 644 "$config_sample"
+        log "Installed partition config sample from $config_source to $config_sample"
     fi
     
-    # If config already exists, don't overwrite
+    # If live config already exists, don't overwrite (preserves operator edits)
     if [ -f "$config_dest" ]; then
-        log "Partition configuration already exists at $config_dest"
+        log "Partition configuration already exists at $config_dest (not overwriting)"
         return 0
     fi
     
-    # Create sample configuration
+    # Create live config from sample if available, otherwise create default
+    if [ -f "$config_sample" ]; then
+        cp "$config_sample" "$config_dest"
+        chmod 644 "$config_dest"
+        log "Initialized partition config from sample: $config_dest"
+        return 0
+    fi
+    
+    # Create default configuration
     cat > "$config_dest" << 'EOF'
 # Partition Configuration for Load-Balanced Job Submission
 # Format: partition: fallback1,fallback2,fallback3

--- a/projects/cc-ooc-handler/specs/default/cluster-init/scripts/01_install_capacity_check.sh
+++ b/projects/cc-ooc-handler/specs/default/cluster-init/scripts/01_install_capacity_check.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+# Capacity Check Service Installation Script
+# This script installs and configures the capacity_check.sh as a systemd service
+# to monitor CycleCloud cluster capacity and handle out-of-capacity scenarios
+
+set -euo pipefail
+
+# Global variables
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+LOG_FILE="/var/log/capacity_check.log"
+SERVICE_NAME="capacity-check"
+INSTALL_DIR="/opt/azurehpc/slurm"
+
+# Source common functions
+source "$SCRIPT_DIR/../files/common.sh"
+
+# Check if this is the scheduler node
+check_scheduler_node
+
+# Load configuration from environment file if it exists
+load_configuration() {
+    load_base_configuration "$SCRIPT_DIR"
+    
+    # Capacity check service configuration
+    CAPACITY_CHECK_INTERVAL="${CAPACITY_CHECK_INTERVAL:-300}"
+    INSTALL_DIR="${INSTALL_DIR:-/opt/azurehpc/slurm}"
+    
+    # Verify INSTALL_DIR exists
+    if [ ! -d "$INSTALL_DIR" ]; then
+        error_exit "Install directory $INSTALL_DIR does not exist"
+    fi
+    
+    log "Configuration loaded:"
+    log "  Capacity check interval: ${CAPACITY_CHECK_INTERVAL}s"
+    log "  Install directory: $INSTALL_DIR"
+}
+
+# Install the capacity check script
+install_script() {
+    log "Installing capacity check script..."
+    
+    local script_source="$SCRIPT_DIR/../files/capacity_check.sh"
+    local script_dest="$INSTALL_DIR/capacity_check.sh"
+    
+    if [ -f "$script_source" ]; then
+        cp "$script_source" "$script_dest"
+        chmod 755 "$script_dest"
+        log "Installed script to $script_dest"
+    else
+        error_exit "Script source file not found at $script_source"
+    fi
+}
+
+# Install logrotate configuration
+install_logrotate() {
+    log "Installing logrotate configuration..."
+    
+    local logrotate_source="$SCRIPT_DIR/../files/capacity_check.logrotate"
+    local logrotate_dest="/etc/logrotate.d/capacity-check"
+    
+    if [ -f "$logrotate_source" ]; then
+        cp "$logrotate_source" "$logrotate_dest"
+        chmod 644 "$logrotate_dest"
+        log "Installed logrotate config to $logrotate_dest"
+    else
+        log "WARNING: Logrotate config not found at $logrotate_source, skipping"
+    fi
+}
+
+# Create and install the systemd service unit
+install_systemd_service() {
+    log "Installing systemd service..."
+    
+    local service_file="/etc/systemd/system/${SERVICE_NAME}.service"
+    local timer_file="/etc/systemd/system/${SERVICE_NAME}.timer"
+    
+    # Create the service unit (oneshot, triggered by timer)
+    cat > "$service_file" << EOF
+[Unit]
+Description=CycleCloud Capacity Check for Slurm
+After=network.target slurmctld.service
+Requires=slurmctld.service
+BindsTo=slurmctld.service
+
+[Service]
+Type=oneshot
+ExecStart=$INSTALL_DIR/capacity_check.sh
+StandardOutput=append:/var/log/capacity_check.log
+StandardError=append:/var/log/capacity_check.log
+User=root
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    chmod 644 "$service_file"
+    log "Created service unit: $service_file"
+    
+    # Create the timer unit
+    cat > "$timer_file" << EOF
+[Unit]
+Description=Run CycleCloud Capacity Check periodically
+After=slurmctld.service
+Requires=slurmctld.service
+
+[Timer]
+OnBootSec=60
+OnUnitActiveSec=${CAPACITY_CHECK_INTERVAL}
+AccuracySec=10
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+EOF
+    chmod 644 "$timer_file"
+    log "Created timer unit: $timer_file"
+}
+
+# Enable and start the systemd timer
+enable_service() {
+    log "Enabling and starting capacity check timer..."
+    
+    systemctl daemon-reload
+    systemctl enable "${SERVICE_NAME}.timer"
+    systemctl start "${SERVICE_NAME}.timer"
+    
+    log "Timer enabled and started"
+    log "Timer status:"
+    systemctl status "${SERVICE_NAME}.timer" --no-pager || true
+}
+
+# Main installation function
+main() {
+    log "========================================="
+    log "Starting Capacity Check Service Installation"
+    log "=========================================="
+    
+    load_configuration
+    install_script
+    install_logrotate
+    install_systemd_service
+    enable_service
+    
+    log "=========================================="
+    log "Capacity Check Service Installation Complete"
+    log "=========================================="
+    log ""
+    log "The capacity check runs every ${CAPACITY_CHECK_INTERVAL} seconds."
+    log "To check status: systemctl status ${SERVICE_NAME}.timer"
+    log "To view logs: tail -f /var/log/capacity_check.log"
+    log "To run manually: systemctl start ${SERVICE_NAME}.service"
+}
+
+main "$@"

--- a/projects/cc-ooc-handler/specs/default/cluster-init/scripts/01_install_capacity_check.sh
+++ b/projects/cc-ooc-handler/specs/default/cluster-init/scripts/01_install_capacity_check.sh
@@ -134,6 +134,11 @@ main() {
     log "Starting Capacity Check Service Installation"
     log "=========================================="
     
+    # Ensure running as root
+    if [ "$(id -u)" -ne 0 ]; then
+        error_exit "This script must be run as root"
+    fi
+    
     load_configuration
     install_script
     install_logrotate

--- a/projects/cc-ooc-handler/specs/default/cluster-init/scripts/01_install_capacity_check.sh
+++ b/projects/cc-ooc-handler/specs/default/cluster-init/scripts/01_install_capacity_check.sh
@@ -79,8 +79,6 @@ install_systemd_service() {
 [Unit]
 Description=CycleCloud Capacity Check for Slurm
 After=network.target slurmctld.service
-Requires=slurmctld.service
-BindsTo=slurmctld.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
# Pull Request Description

## Summary

This PR introduces a comprehensive Out-of-Capacity (OOC) handler for Slurm clusters deployed on Azure CycleCloud. The solution implements load-balanced partition assignment to handle capacity constraints and improve job scheduling efficiency across multiple Azure regions.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration change
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Issues

N/A

## Changes Made

This PR adds a new CycleCloud project `cc-ooc-handler` that provides:

### Core Components

1. **Slurm Job Submit Plugin** (`job_submit_round_robin.lua`)
   - Intercepts job submissions at the Slurm scheduler level
   - Implements load-balanced partition assignment based on node allocation
   - Automatically routes jobs to the least-loaded partition from configured fallback options
   - Skips partitions marked as INACTIVE in the capacity state file

2. **Capacity Check Service** (`capacity_check.sh`)
   - Monitors Azure VM capacity availability across regions
   - Detects out-of-capacity scenarios for configured VM types
   - Updates partition states (ACTIVE/INACTIVE) based on capacity availability
   - Integrates with Slurm partition management

3. **Configuration Management**
   - Partition mapping configuration (`partition_config.conf`)
   - Centralized environment configuration (`ooc-handler-config.env`)
   - Log rotation for capacity monitoring

### Installation Scripts

- `00_install_job_plugin.sh` - Installs and configures the Slurm job submit plugin
- `01_install_capacity_check.sh` - Sets up the capacity monitoring service

### Documentation

- Comprehensive README with installation and configuration instructions
- Inline documentation for the job submit plugin
- Configuration examples and usage guidelines

## How It Works

1. **Partition Mapping**: Define logical-to-physical partition mappings in `/etc/slurm/partition_config.conf`
   ```
   # Example: hpc partition maps to three regional fallbacks
   hpc: hpc_eastus,hpc_westus,hpc_northeu
   ```

2. **Job Submission**: When a job targets a mapped partition:
   - Plugin queries current load across all fallback partitions
   - Assigns job to the partition with lowest node allocation
   - Skips any partitions marked INACTIVE by capacity checker

3. **Capacity Monitoring**: Background service continuously:
   - Checks VM capacity in configured Azure regions
   - Marks partitions INACTIVE when capacity is exhausted
   - Marks partitions ACTIVE when capacity becomes available

## Configuration Variables

| Variable | Default | Description |
|----------|---------|-------------|
| `DEBUG_LOGGING` | `false` | Enable verbose installation logging |
| `SLURM_CONFIG_DIR` | `/etc/slurm` | Slurm configuration directory |
| `SLURM_STATE_DIR` | `/var/run/slurm` | Directory for capacity state file |

## Testing

- [x] Manual testing performed

### Test Approach

This is a CycleCloud cluster configuration project that:
- Deploys via CycleCloud's cluster-init mechanism
- Integrates with existing Slurm infrastructure
- Requires Azure VM capacity monitoring

Testing validates:
- Script syntax and structure
- Configuration file formats
- Slurm integration points
- Installation workflow

### Test Environment

- OS: Linux (compatible with CycleCloud Slurm clusters)
- Platform: Azure CycleCloud
- Slurm Version: Compatible with Lua job_submit plugin API

## Files Added

- `projects/cc-ooc-handler/README.md` - Project documentation
- `projects/cc-ooc-handler/project.ini` - CycleCloud project configuration
- `projects/cc-ooc-handler/specs/default/cluster-init/files/capacity_check.logrotate` - Log rotation config
- `projects/cc-ooc-handler/specs/default/cluster-init/files/capacity_check.md` - Capacity checker docs
- `projects/cc-ooc-handler/specs/default/cluster-init/files/capacity_check.sh` - Capacity monitoring script
- `projects/cc-ooc-handler/specs/default/cluster-init/files/common.sh` - Shared utility functions
- `projects/cc-ooc-handler/specs/default/cluster-init/files/job_round_robin.md` - Job plugin docs
- `projects/cc-ooc-handler/specs/default/cluster-init/files/job_submit_round_robin.lua` - Slurm job plugin
- `projects/cc-ooc-handler/specs/default/cluster-init/files/ooc-handler-config.env` - Environment config
- `projects/cc-ooc-handler/specs/default/cluster-init/files/partition_config.conf` - Partition mappings
- `projects/cc-ooc-handler/specs/default/cluster-init/scripts/00_install_job_plugin.sh` - Plugin installer
- `projects/cc-ooc-handler/specs/default/cluster-init/scripts/01_install_capacity_check.sh` - Capacity checker installer

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots

N/A - This is a backend service/infrastructure component with no UI.

## Additional Notes

### Benefits

- **Improved Job Success Rates**: Automatically routes jobs away from capacity-constrained regions
- **Better Resource Utilization**: Distributes workload across available capacity
- **Reduced Manual Intervention**: Automatic handling of OOC scenarios
- **Multi-Region Support**: Seamlessly works across Azure regions

### Deployment

This project integrates with Azure CycleCloud's cluster-init mechanism and will be automatically deployed when:
1. The project is uploaded to CycleCloud
2. Referenced in a cluster template
3. The cluster is started

### Post-Installation Requirements

After deployment, administrators should:
1. Configure partition mappings in `/etc/slurm/partition_config.conf`
2. Restart `slurmctld` to activate the job submit plugin
3. Verify capacity monitoring is running
4. Monitor logs in `/var/log/slurm/capacity_check.log`